### PR TITLE
fix(ci): add .eslintrc.js and remove unused imports

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: ['@headlamp-k8s/eslint-config'],
+};

--- a/src/components/BlockPoolsPage.tsx
+++ b/src/components/BlockPoolsPage.tsx
@@ -11,8 +11,8 @@ import {
   StatusLabel,
 } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
 import React, { useState } from 'react';
-import { useRookCephContext } from '../api/RookCephDataContext';
 import { CephBlockPool, formatAge, phaseToStatus } from '../api/k8s';
+import { useRookCephContext } from '../api/RookCephDataContext';
 
 function BlockPoolDetail({ pool, onClose }: { pool: CephBlockPool; onClose: () => void }) {
   return (

--- a/src/components/CephPodDetailSection.tsx
+++ b/src/components/CephPodDetailSection.tsx
@@ -11,7 +11,7 @@ import {
   StatusLabel,
 } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
 import React from 'react';
-import { formatAge, getPodRestarts } from '../api/k8s';
+import { formatAge } from '../api/k8s';
 
 interface CephPodDetailSectionProps {
   resource: {

--- a/src/components/OverviewPage.tsx
+++ b/src/components/OverviewPage.tsx
@@ -15,8 +15,8 @@ import {
   StatusLabel,
 } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
 import React from 'react';
-import { useRookCephContext } from '../api/RookCephDataContext';
 import { formatAge, formatBytes, healthToStatus, phaseToStatus, storageClassType } from '../api/k8s';
+import { useRookCephContext } from '../api/RookCephDataContext';
 import ClusterStatusCard from './ClusterStatusCard';
 
 export default function OverviewPage() {

--- a/src/components/PVCDetailSection.tsx
+++ b/src/components/PVCDetailSection.tsx
@@ -10,8 +10,8 @@ import {
   SectionBox,
 } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
 import React from 'react';
+import { findBoundPv, formatStorageType } from '../api/k8s';
 import { useRookCephContext } from '../api/RookCephDataContext';
-import { findBoundPv, formatStorageType, storageClassType } from '../api/k8s';
 
 interface PVCDetailSectionProps {
   resource: {

--- a/src/components/PodsPage.tsx
+++ b/src/components/PodsPage.tsx
@@ -11,8 +11,8 @@ import {
   StatusLabel,
 } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
 import React from 'react';
-import { useRookCephContext } from '../api/RookCephDataContext';
 import { formatAge, getPodRestarts, isPodReady, RookCephPod } from '../api/k8s';
+import { useRookCephContext } from '../api/RookCephDataContext';
 
 function PodTable({ pods, title }: { pods: RookCephPod[]; title: string }) {
   if (pods.length === 0) return null;

--- a/src/components/StorageClassesPage.tsx
+++ b/src/components/StorageClassesPage.tsx
@@ -11,8 +11,8 @@ import {
   StatusLabel,
 } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
 import React, { useState } from 'react';
-import { useRookCephContext } from '../api/RookCephDataContext';
 import { formatAge, formatStorageType, RookCephStorageClass, storageClassType } from '../api/k8s';
+import { useRookCephContext } from '../api/RookCephDataContext';
 
 function StorageClassDetail({ sc, pvCount, onClose }: { sc: RookCephStorageClass; pvCount: number; onClose: () => void }) {
   const type = storageClassType(sc);

--- a/src/components/VolumesPage.tsx
+++ b/src/components/VolumesPage.tsx
@@ -11,8 +11,8 @@ import {
   StatusLabel,
 } from '@kinvolk/headlamp-plugin/lib/CommonComponents';
 import React, { useState } from 'react';
-import { useRookCephContext } from '../api/RookCephDataContext';
 import { formatAccessModes, formatAge, phaseToStatus, RookCephPersistentVolume } from '../api/k8s';
+import { useRookCephContext } from '../api/RookCephDataContext';
 
 function PVDetail({ pv, onClose }: { pv: RookCephPersistentVolume; onClose: () => void }) {
   const attrs = pv.spec.csi?.volumeAttributes ?? {};

--- a/src/components/integrations/StorageClassColumns.tsx
+++ b/src/components/integrations/StorageClassColumns.tsx
@@ -7,7 +7,7 @@
  */
 
 import React from 'react';
-import { isRookCephProvisioner, formatStorageType } from '../../api/k8s';
+import { formatStorageType, isRookCephProvisioner } from '../../api/k8s';
 
 /** Safely read a nested field from either a KubeObject instance or plain object. */
 function getField(item: unknown, ...path: string[]): unknown {


### PR DESCRIPTION
## Summary

- Add `.eslintrc.js` extending `@headlamp-k8s/eslint-config` — CI was failing because ESLint couldn't find a config file
- Remove two unused imports (`getPodRestarts` in `CephPodDetailSection.tsx`, `storageClassType` in `PVCDetailSection.tsx`)
- Run `lint:fix` to auto-sort imports across all files

## Test plan

- [ ] CI lint step passes
- [ ] CI type-check passes
- [ ] CI tests pass (37 tests)

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)